### PR TITLE
[#1] 회원가입 기능 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.security:spring-security-crypto'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/community/global/base/BaseEntity.java
+++ b/src/main/java/com/community/global/base/BaseEntity.java
@@ -1,0 +1,30 @@
+package com.community.global.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+public class BaseEntity {
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    protected BaseEntity() {
+    }
+
+    public BaseEntity(LocalDateTime createdAt, LocalDateTime updatedAt) {
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/com/community/global/config/SecurityConfig.java
+++ b/src/main/java/com/community/global/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package com.community.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/community/member/controller/MemberController.java
+++ b/src/main/java/com/community/member/controller/MemberController.java
@@ -1,6 +1,6 @@
 package com.community.member.controller;
 
-import com.community.member.controller.dto.MemberSignUpRequest;
+import com.community.member.controller.dto.MemberCreateRequest;
 import com.community.member.service.MemberService;
 import com.community.member.service.dto.MemberDto;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +20,7 @@ public class MemberController {
     private final MemberService memberService;
 
     @PostMapping
-    public ResponseEntity<MemberDto> createMember(@RequestBody MemberSignUpRequest request) {
+    public ResponseEntity<MemberDto> createMember(@RequestBody MemberCreateRequest request) {
         MemberDto response = memberService.create(request);
         URI uri = URI.create(String.valueOf(response.id()));
         return ResponseEntity

--- a/src/main/java/com/community/member/controller/MemberController.java
+++ b/src/main/java/com/community/member/controller/MemberController.java
@@ -1,0 +1,30 @@
+package com.community.member.controller;
+
+import com.community.member.controller.dto.MemberSignUpRequest;
+import com.community.member.service.MemberService;
+import com.community.member.service.dto.MemberDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/member")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PostMapping
+    public ResponseEntity<MemberDto> createMember(@RequestBody MemberSignUpRequest request) {
+        MemberDto response = memberService.create(request);
+        URI uri = URI.create(String.valueOf(response.id()));
+        return ResponseEntity
+                .created(uri)
+                .body(response);
+    }
+}

--- a/src/main/java/com/community/member/controller/dto/MemberCreateRequest.java
+++ b/src/main/java/com/community/member/controller/dto/MemberCreateRequest.java
@@ -1,0 +1,5 @@
+package com.community.member.controller.dto;
+
+public record MemberCreateRequest(String email, String password) {
+
+}

--- a/src/main/java/com/community/member/controller/dto/MemberSignUpRequest.java
+++ b/src/main/java/com/community/member/controller/dto/MemberSignUpRequest.java
@@ -1,0 +1,5 @@
+package com.community.member.controller.dto;
+
+public record MemberSignUpRequest(String email, String password) {
+
+}

--- a/src/main/java/com/community/member/controller/dto/MemberSignUpRequest.java
+++ b/src/main/java/com/community/member/controller/dto/MemberSignUpRequest.java
@@ -1,5 +1,0 @@
-package com.community.member.controller.dto;
-
-public record MemberSignUpRequest(String email, String password) {
-
-}

--- a/src/main/java/com/community/member/domain/Member.java
+++ b/src/main/java/com/community/member/domain/Member.java
@@ -1,0 +1,36 @@
+package com.community.member.domain;
+
+import com.community.global.base.BaseEntity;
+import com.community.member.domain.vo.Email;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private Email email;
+
+    public Member(Long id, Email email, LocalDateTime createdAt, LocalDateTime updatedAt) {
+        super(createdAt, updatedAt);
+        this.id = id;
+        this.email = email;
+    }
+
+    public static Member of(String email) {
+        return new Member(
+                null,
+                Email.of(email),
+                LocalDateTime.now(),
+                null);
+    }
+}

--- a/src/main/java/com/community/member/domain/Member.java
+++ b/src/main/java/com/community/member/domain/Member.java
@@ -1,6 +1,7 @@
 package com.community.member.domain;
 
 import com.community.global.base.BaseEntity;
+import com.community.member.domain.repository.MemberRepository;
 import com.community.member.domain.vo.Email;
 import com.community.member.domain.vo.Password;
 import jakarta.persistence.*;
@@ -33,12 +34,18 @@ public class Member extends BaseEntity {
         this.password = password;
     }
 
-    public static Member of(String email, String password, PasswordEncoder passwordEncoder) {
+    public static Member of(
+            String email,
+            String password,
+            PasswordEncoder passwordEncoder,
+            MemberRepository memberRepository
+    ) {
         return new Member(
                 null,
-                Email.of(email),
+                Email.of(email, memberRepository),
                 Password.of(password, passwordEncoder),
                 LocalDateTime.now(),
-                null);
+                null
+        );
     }
 }

--- a/src/main/java/com/community/member/domain/Member.java
+++ b/src/main/java/com/community/member/domain/Member.java
@@ -2,13 +2,16 @@ package com.community.member.domain;
 
 import com.community.global.base.BaseEntity;
 import com.community.member.domain.vo.Email;
+import com.community.member.domain.vo.Password;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDateTime;
 
-
+@Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
@@ -20,16 +23,21 @@ public class Member extends BaseEntity {
     @Embedded
     private Email email;
 
-    public Member(Long id, Email email, LocalDateTime createdAt, LocalDateTime updatedAt) {
+    @Embedded
+    private Password password;
+
+    public Member(Long id, Email email, Password password, LocalDateTime createdAt, LocalDateTime updatedAt) {
         super(createdAt, updatedAt);
         this.id = id;
         this.email = email;
+        this.password = password;
     }
 
-    public static Member of(String email) {
+    public static Member of(String email, String password, PasswordEncoder passwordEncoder) {
         return new Member(
                 null,
                 Email.of(email),
+                Password.of(password, passwordEncoder),
                 LocalDateTime.now(),
                 null);
     }

--- a/src/main/java/com/community/member/domain/repository/MemberJpaRepository.java
+++ b/src/main/java/com/community/member/domain/repository/MemberJpaRepository.java
@@ -1,0 +1,12 @@
+package com.community.member.domain.repository;
+
+import com.community.member.domain.Member;
+import com.community.member.domain.vo.Email;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MemberJpaRepository extends JpaRepository<Member, Long> {
+
+    boolean existsMemberByEmail(Email email);
+}

--- a/src/main/java/com/community/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/community/member/domain/repository/MemberRepository.java
@@ -1,0 +1,11 @@
+package com.community.member.domain.repository;
+
+import com.community.member.domain.Member;
+import com.community.member.domain.vo.Email;
+
+public interface MemberRepository {
+
+    Member save(Member member);
+
+    boolean existsMemberByEmail(Email email);
+}

--- a/src/main/java/com/community/member/domain/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/community/member/domain/repository/MemberRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.community.member.domain.repository;
+
+import com.community.member.domain.Member;
+import com.community.member.domain.vo.Email;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository {
+
+    private final MemberJpaRepository jpaRepository;
+
+    @Override
+    public Member save(Member member) {
+        return jpaRepository.save(member);
+    }
+
+    @Override
+    public boolean existsMemberByEmail(Email email) {
+        return jpaRepository.existsMemberByEmail(email);
+    }
+}

--- a/src/main/java/com/community/member/domain/vo/Email.java
+++ b/src/main/java/com/community/member/domain/vo/Email.java
@@ -1,5 +1,6 @@
 package com.community.member.domain.vo;
 
+import com.community.member.domain.repository.MemberRepository;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import lombok.AccessLevel;
@@ -22,8 +23,9 @@ public class Email {
         this.value = email;
     }
 
-    public static Email of(String email) {
+    public static Email of(String email, MemberRepository memberRepository) {
         validateEmail(email);
+        checkDuplicateEmail(email, memberRepository);
         return new Email(email);
     }
 
@@ -35,6 +37,12 @@ public class Email {
         Pattern pattern = Pattern.compile(EMAIL_PATTERN);
         if (!pattern.matcher(email).matches()) {
             throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+        }
+    }
+
+    private static void checkDuplicateEmail(String email, MemberRepository memberRepository) {
+        if (memberRepository.existsMemberByEmail(new Email(email))) {
+            throw new IllegalArgumentException("중복된 이메일입니다.");
         }
     }
 }

--- a/src/main/java/com/community/member/domain/vo/Email.java
+++ b/src/main/java/com/community/member/domain/vo/Email.java
@@ -1,0 +1,40 @@
+package com.community.member.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.regex.Pattern;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Email {
+
+    private static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+
+    @Column(name = "email", nullable = false)
+    private String value;
+
+    public Email(String email) {
+        this.value = email;
+    }
+
+    public static Email of(String email) {
+        validateEmail(email);
+        return new Email(email);
+    }
+
+    private static void validateEmail(String email) {
+        if (email == null || email.isEmpty()) {
+            throw new IllegalArgumentException("이메일은 필수입니다.");
+        }
+
+        Pattern pattern = Pattern.compile(EMAIL_PATTERN);
+        if (!pattern.matcher(email).matches()) {
+            throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/community/member/domain/vo/Password.java
+++ b/src/main/java/com/community/member/domain/vo/Password.java
@@ -1,0 +1,41 @@
+package com.community.member.domain.vo;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.regex.Pattern;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Password {
+
+    public static final String PASSWORD_PATTERN = "^[a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>/?]{8,20}$";
+
+    @Column(name = "password", nullable = false)
+    private String value;
+
+    public Password(String value) {
+        this.value = value;
+    }
+
+    public static Password of(String rawPassword, PasswordEncoder passwordEncoder) {
+        validatePassword(rawPassword);
+        return new Password(passwordEncoder.encode(rawPassword));
+    }
+
+    private static void validatePassword(String rawPassword) {
+        if (rawPassword == null || rawPassword.isEmpty()) {
+            throw new IllegalArgumentException("비밀번호는 필수입니다.");
+        }
+
+        Pattern pattern = Pattern.compile(PASSWORD_PATTERN);
+        if (!pattern.matcher(rawPassword).matches()) {
+            throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+        }
+    }
+}

--- a/src/main/java/com/community/member/service/MemberService.java
+++ b/src/main/java/com/community/member/service/MemberService.java
@@ -1,0 +1,24 @@
+package com.community.member.service;
+
+import com.community.member.controller.dto.MemberSignUpRequest;
+import com.community.member.domain.Member;
+import com.community.member.domain.repository.MemberRepository;
+import com.community.member.service.dto.MemberDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public MemberDto create(MemberSignUpRequest request) {
+        Member member = Member.of(request.email(), request.password(), passwordEncoder, memberRepository);
+        return MemberDto.from(memberRepository.save(member));
+    }
+}

--- a/src/main/java/com/community/member/service/MemberService.java
+++ b/src/main/java/com/community/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.community.member.service;
 
-import com.community.member.controller.dto.MemberSignUpRequest;
+import com.community.member.controller.dto.MemberCreateRequest;
 import com.community.member.domain.Member;
 import com.community.member.domain.repository.MemberRepository;
 import com.community.member.service.dto.MemberDto;
@@ -17,7 +17,7 @@ public class MemberService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public MemberDto create(MemberSignUpRequest request) {
+    public MemberDto create(MemberCreateRequest request) {
         Member member = Member.of(request.email(), request.password(), passwordEncoder, memberRepository);
         return MemberDto.from(memberRepository.save(member));
     }

--- a/src/main/java/com/community/member/service/dto/MemberDto.java
+++ b/src/main/java/com/community/member/service/dto/MemberDto.java
@@ -1,0 +1,10 @@
+package com.community.member.service.dto;
+
+import com.community.member.domain.Member;
+
+public record MemberDto(Long id, String email) {
+
+    public static MemberDto from(Member member) {
+        return new MemberDto(member.getId(), member.getEmail().getValue());
+    }
+}

--- a/src/test/java/com/community/member/domain/EmailTest.java
+++ b/src/test/java/com/community/member/domain/EmailTest.java
@@ -1,20 +1,33 @@
 package com.community.member.domain;
 
+import com.community.member.domain.repository.MemberRepository;
 import com.community.member.domain.vo.Email;
+import com.community.member.repository.InMemoryMemberRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class EmailTest {
 
+    MemberRepository memberRepository;
+    PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = new InMemoryMemberRepository();
+    }
+
     @Test
     @DisplayName("유효한 이메일로 Email 객체 생성 성공")
     void createEmail_success() {
         String validEmail = "test@gmail.com";
 
-        Email response = Email.of(validEmail);
+        Email response = Email.of(validEmail, memberRepository);
 
         assertThat(response).isNotNull();
         assertThat(response.getValue()).isEqualTo(validEmail);
@@ -25,7 +38,7 @@ public class EmailTest {
     void createEmail_nullEmail() {
         String nullEmail = null;
 
-        assertThatThrownBy(() -> Email.of(nullEmail))
+        assertThatThrownBy(() -> Email.of(nullEmail, memberRepository))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -34,7 +47,7 @@ public class EmailTest {
     void createEmail_emptyEmail() {
         String emptyEmail = "";
 
-        assertThatThrownBy(() -> Email.of(emptyEmail))
+        assertThatThrownBy(() -> Email.of(emptyEmail, memberRepository))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -43,7 +56,7 @@ public class EmailTest {
     void createEmail_invalidEmail() {
         String invalidEmail = "@.";
 
-        assertThatThrownBy(() -> Email.of(invalidEmail))
+        assertThatThrownBy(() -> Email.of(invalidEmail, memberRepository))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -52,7 +65,7 @@ public class EmailTest {
     void createEmail_invalidEmail2() {
         String invalidEmail = "invalid@email";
 
-        assertThatThrownBy(() -> Email.of(invalidEmail))
+        assertThatThrownBy(() -> Email.of(invalidEmail, memberRepository))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -61,7 +74,19 @@ public class EmailTest {
     void createEmail_invalidEmail3() {
         String invalidEmail = "invalid-email";
 
-        assertThatThrownBy(() -> Email.of(invalidEmail))
+        assertThatThrownBy(() -> Email.of(invalidEmail, memberRepository))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("중복된 이메일로 Email 객체 생성시 예외")
+    void createEmail_duplicateEmail() {
+        String existedEmail = "test@gmail.com";
+
+        Member member = Member.of(existedEmail, "testPassword", passwordEncoder, memberRepository);
+        memberRepository.save(member);
+
+        assertThatThrownBy(() -> Email.of(existedEmail, memberRepository))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/src/test/java/com/community/member/domain/EmailTest.java
+++ b/src/test/java/com/community/member/domain/EmailTest.java
@@ -1,0 +1,67 @@
+package com.community.member.domain;
+
+import com.community.member.domain.vo.Email;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class EmailTest {
+
+    @Test
+    @DisplayName("유효한 이메일로 Email 객체 생성 성공")
+    void createEmail_success() {
+        String validEmail = "test@gmail.com";
+
+        Email response = Email.of(validEmail);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getValue()).isEqualTo(validEmail);
+    }
+
+    @Test
+    @DisplayName("입력값이 null인 경우 예외 발생")
+    void createEmail_nullEmail() {
+        String nullEmail = null;
+
+        assertThatThrownBy(() -> Email.of(nullEmail))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("입력값이 빈 문자열인 경우 예외 발생")
+    void createEmail_emptyEmail() {
+        String emptyEmail = "";
+
+        assertThatThrownBy(() -> Email.of(emptyEmail))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("입력값이 잘못된 형식인 경우 예외 발생")
+    void createEmail_invalidEmail() {
+        String invalidEmail = "@.";
+
+        assertThatThrownBy(() -> Email.of(invalidEmail))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("입력값이 잘못된 형식인 경우 예외 발생2")
+    void createEmail_invalidEmail2() {
+        String invalidEmail = "invalid@email";
+
+        assertThatThrownBy(() -> Email.of(invalidEmail))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("입력값이 잘못된 형식인 경우 예외 발생3")
+    void createEmail_invalidEmail3() {
+        String invalidEmail = "invalid-email";
+
+        assertThatThrownBy(() -> Email.of(invalidEmail))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/community/member/domain/PasswordTest.java
+++ b/src/test/java/com/community/member/domain/PasswordTest.java
@@ -1,0 +1,99 @@
+package com.community.member.domain;
+
+import com.community.member.domain.vo.Password;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class PasswordTest {
+
+    private PasswordEncoder passwordEncoder;
+
+    @BeforeEach
+    void setUp() {
+        passwordEncoder = new BCryptPasswordEncoder();
+    }
+
+    @Test
+    @DisplayName("유효한 비밀번호로 Password 객체 생성 완료")
+    void passwordCreate_success() {
+        String rawPassword = "valid-String";
+
+        Password password = Password.of(rawPassword, passwordEncoder);
+
+        assertNotNull(password);
+        assertNotEquals(rawPassword, password.getValue());
+        assertTrue(passwordEncoder.matches(rawPassword, password.getValue()));
+    }
+
+    @Test
+    @DisplayName("특수문자가 포함된 유효한 비밀번호로 Password 객체 생성 완료")
+    void passwordCreate_success_special() {
+        String rawPassword = "@String,.,!@#";
+
+        Password password = Password.of(rawPassword, passwordEncoder);
+
+        assertNotNull(password);
+        assertNotEquals(rawPassword, password.getValue());
+        assertTrue(passwordEncoder.matches(rawPassword, password.getValue()));
+    }
+
+    @Test
+    @DisplayName("비밀번호가 null인 경우 예외 발생")
+    void passwordCreate_nullPassword() {
+        String rawPassword = null;
+
+        assertThatThrownBy(() -> Password.of(rawPassword, passwordEncoder))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 짧은 경우 예외 발생")
+    void passwordCreate_shortPassword() {
+        String rawPassword = "short";
+
+        assertThatThrownBy(() -> Password.of(rawPassword, passwordEncoder))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 긴 경우 예외 발생")
+    void passwordCreate_longPassword() {
+        String rawPassword = "long-password-1231231231231212312312123123123123";
+
+        assertThatThrownBy(() -> Password.of(rawPassword, passwordEncoder))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 비어있는 문자열인 경우 예외 발생")
+    void passwordCreate_emptyPassword() {
+        String rawPassword = "";
+
+        assertThatThrownBy(() -> Password.of(rawPassword, passwordEncoder))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 공백만 8번일 경우 예외 발생")
+    void passwordCreate_blankPassword() {
+        String rawPassword = "        ";
+
+        assertThatThrownBy(() -> Password.of(rawPassword, passwordEncoder))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("비밀번호가 공백 포함 8자일 경우 예외 발생")
+    void passwordCreate_invalidPassword() {
+        String rawPassword = "p ssword";
+
+        assertThatThrownBy(() -> Password.of(rawPassword, passwordEncoder))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/community/member/repository/InMemoryMemberRepository.java
+++ b/src/test/java/com/community/member/repository/InMemoryMemberRepository.java
@@ -1,0 +1,27 @@
+package com.community.member.repository;
+
+import com.community.member.domain.Member;
+import com.community.member.domain.repository.MemberRepository;
+import com.community.member.domain.vo.Email;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class InMemoryMemberRepository implements MemberRepository {
+
+    private final Map<Long, Member> members = new HashMap<>();
+
+    @Override
+    public Member save(Member member) {
+        Long id = (long) (members.size() + 1);
+        members.put(id, member);
+        return member;
+    }
+
+    @Override
+    public boolean existsMemberByEmail(Email email) {
+        return members.values()
+                .stream()
+                .anyMatch(member -> member.getEmail().getValue().equals(email.getValue()));
+    }
+}


### PR DESCRIPTION
## 구현 목표
> 계층별 역할을 명확히 구분하고, 적용하여 도메인에 집중하기.


## 클래스 다이어그램
![스크린샷 2024-10-03 오후 6 22 14](https://github.com/user-attachments/assets/533bca8b-54d6-4cac-9234-1da4eb8e19f1)



계층형 아키텍처에 따라 `Controller -> Service -> Domain -> Repository`로 구조를 나누었으며, 도메인 계층에서 비즈니스 로직을 구현했습니다. 하지만 이메일 중복 검사 로직을 구현하는 과정에서 도메인의 Email 클래스가 특정 Repository 구현에 의존하는 문제가 발생했습니다.

이와 같은 구조에서는 Repository 클래스가 변경될 경우 이를 참조하는 Domain과 Service, Controller까지 영향을 받을 수 있어, 변경에 취약한 구조가 됩니다. 특히 도메인 계층은 모든 설계와 코드에서 최우선 순위를 지켜야 하고, 프레임워크나 다른 계층에 종속되지 않아야 합니다. 

이를 해결하기 위해 Repository를 추상화 하고, 도메인 계층에서 의존성을 구현체가 아닌 인터페이스를 통해 주입받도록 변경했습니다. MemberRepositoryImpl 클래스는 MemberRepository를 구현하고, MemberJpaRepository를 이용해 실제 동작 합니다. 이를 통해 Repository의 구현이 변경되더라도 도메인 로직에는 최소한의 영향을 미치도록 했습니다.


## DTO의 역할
> DTO(Data Transfer Object) : 클라이언트와 서버 간, 또는 계층 간 데이터 전송을 위해 설계된 객체

DTO의 역할을 명확히 구분하여 사용하려고 노력했습니다. DTO는 클라이언트와 서버 간, 또는 Controller와 Service 계층 간에서만 사용되도록 하였습니다.

회원가입 요청시 회원가입 요청시 controller 계층에서는 MemberCreateRequest DTO로 데이터를 받고, 이를 Service 계층으로 전달하여 처리했습니다. Service 계층과 Domain 계층에서 로직을 처리한 후, MemberDto를 통해 Controller로 리턴했습니다. 이 과정을 통해 Entity를 Controller 계층에 노출하지 않도록 설계했습니다.

또한, Domain이 DTO에 의존하지 않도록 했습니다. 회원의 정보를 담고있는 MemberDto를 Entity에서 toDto 메서드를 사용해 변환하는 것이 아닌, Service 계층에서 직접 Dto의 정적 팩토리 메서드를 이용해 변환했습니다. 
